### PR TITLE
use format string and refactor spotify search loop to show progress.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Transfer a Spotify Playlist to YouTube Music
 
-A simple command line script to clone a Spotify playlist to YouTube Music. 
+A simple command line script to clone a Spotify playlist to YouTube Music.
 
 - Transfer a single Spotify playlist
 - Transfer all playlists for a Spotify user
@@ -8,12 +8,12 @@ A simple command line script to clone a Spotify playlist to YouTube Music.
 
 ## Requirements
 
-- Python 3 - https://www.python.org
+- Python 3.6+ - https://www.python.org
 - Python extensions: `pip install -U -r requirements`
 
 ## Setup
 
-1. Initially you should create a new `settings.ini` containing your Spotify credentials. 
+1. Initially you should create a new `settings.ini` containing your Spotify credentials.
 
 Simply copy `settings.ini.example` to a new file `settings.ini`:
 
@@ -25,13 +25,13 @@ $ cp settings.ini.example settings.ini
 
 3. Fill in your `client_id` and `client_secret` from your Spotify app
 
-4. For YouTube Music, open a console in the source code folder and run 
+4. For YouTube Music, open a console in the source code folder and run
 
 `python Setup.py youtube`
 
-Then, open your browser and copy your request headers according to the instructions at https://ytmusicapi.readthedocs.io/en/latest/setup.html 
+Then, open your browser and copy your request headers according to the instructions at https://ytmusicapi.readthedocs.io/en/latest/setup.html
 
-All credentials are stored locally in the file `settings.ini`. 
+All credentials are stored locally in the file `settings.ini`.
 
 ## Transfer a playlist
 

--- a/SpotifyExport.py
+++ b/SpotifyExport.py
@@ -17,16 +17,15 @@ class Spotify:
 
         results = self.api.playlist(playlistId)
         name = results['name']
-        tracks = build_results(results['tracks']['items'])
+        total = int(results['tracks']['total'])
+        tracks = list()
 
-        count = 1
-        more = len(results['tracks']['items']) == 100
-        while more:
-            more_tracks = self.api.playlist_items(playlistId, offset = count * 100, limit=100)
-            print('requested from ' + str(count * 100))
-            tracks += build_results(more_tracks['items'])
-            more = len(more_tracks["items"]) == 100
-            count = count + 1
+        count = 0
+        while count < total:
+            req = self.api.playlist_items(playlistId, offset=count, limit=100)
+            tracks += build_results(req['items'])
+            print(f"Spotify tracks: {len(tracks)}/{total}")
+            count = count + 100
 
         return {'tracks': tracks, 'name': name, 'description': html.unescape(results['description'])}
 

--- a/YouTube.py
+++ b/YouTube.py
@@ -78,10 +78,11 @@ class YTMusicTransfer:
                     videoIds.append(targetSong)
 
             if i > 0 and i % 10 == 0:
-                print(str(i) + ' searched')
+                print(f"YouTube tracks: {i}/{len(songs)}")
 
         with open(path + 'noresults_youtube.txt', 'w', encoding="utf-8") as f:
             f.write("\n".join(notFound))
+            f.write("\n")
             f.close()
 
         return videoIds


### PR DESCRIPTION
* Make it easier to visually confirm  that the all playlist tracks are being processed by using format strings to show progress.

```
$  python3.8 YouTube.py https://open.spotify.com/playlist/0yasezcPZp9GvDpiIonDPv
Spotify tracks: 100/1587
Spotify tracks: 200/1587
...
Spotify tracks: 1400/1587
Spotify tracks: 1500/1587
Spotify tracks: 1587/1587
YouTube tracks: 10/1587
YouTube tracks: 20/1587
YouTube tracks: 30/1587
YouTube tracks: 40/1587
...
```

```
$ python3.8 YouTube.py https://open.spotify.com/playlist/2N5JFUsL1FKuNvnWlii6ZJ
Spotify tracks: 58/58
YouTube tracks: 10/58
YouTube tracks: 20/58
...
```

* Refactored the `getSpotifyPlaylist` to get the tracks in one place in the loop to make it easier to follow.

* Format strings required Python 3.6+ so update the README.md.

* Added a newline to the "noresults" file so that the shell prompt is on a new line after `cat`ing the file.