### PR TITLE
youtube: skip songs that lack duration metadata

### DIFF
--- a/YouTube.py
+++ b/YouTube.py
@@ -26,7 +26,7 @@ class YTMusicTransfer:
                 continue
 
             durationMatch = None
-            if res['duration']:
+            if 'duration' in res:
                 durationItems = res['duration'].split(':')
                 duration = int(durationItems[0]) * 60 + int(durationItems[1])
                 durationMatch = 1 - abs(duration - song['duration']) * 2 / song['duration']


### PR DESCRIPTION
In my playlist Spotify did not return the duration for the following track.

```
{'resultType': 'video', 'title': 'Auditory Canvas - Spring Rain', 'views': None, 'videoId': None, 'year': None, 'artists': [], 'thumbnails': [{...}]}
```

Resulting in the following exception.
```

Traceback (most recent call last):
...
  File "/usr/lib/python3.8/runpy.py", line 95, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.8/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "YouTube.py", line 191, in <module>
    main()
  File "YouTube.py", line 182, in main
    videoIds = ytmusic.search_songs(playlist['tracks'])
  File "YouTube.py", line 75, in search_songs
    targetSong = self.get_best_fit_song_id(result, song)
  File "YouTube.py", line 30, in get_best_fit_song_id
    if res['duration']:
KeyError: 'duration'
```

* Instead of checking if the duration is not-None, check that is exists as a key in the `res` dictionary.