### PR TITLE
Fixes empty song result from stopping the script.

### DIFF
--- a/YouTube.py
+++ b/YouTube.py
@@ -22,6 +22,9 @@ class YTMusicTransfer:
         match_score = {}
         title_score = {}
         for res in results:
+            if res is not dict and len(res) == 0:
+                continue
+
             if res['resultType'] not in ['song', 'video']:
                 continue
 


### PR DESCRIPTION
The script stops when encountering an empty song entry within the song results

- Issue: 
Spotify tracks: 26/26
Traceback (most recent call last):
  File "/Users/sherifnosseir/Developer/spotifyplaylist_to_ytmusic/YouTube.py", line 194, in <module> main() File "/Users/sherifnosseir/Developer/spotifyplaylist_to_ytmusic/YouTube.py", line 186, in main videoIds = ytmusic.search_songs(playlist['tracks']) File "/Users/sherifnosseir/Developer/spotifyplaylist_to_ytmusic/YouTube.py", line 78, in search_songs targetSong = self.get_best_fit_song_id(result, song) File "/Users/sherifnosseir/Developer/spotifyplaylist_to_ytmusic/YouTube.py", line 29, in get_best_fit_song_id if res['resultType'] not in ['song', 'video']: KeyError: 'resultType'

- Inspection 
Note the empty objects in the results array:
{'category': 'Top result', 'resultType': 'video', ...}, {}, {}, {'category': 'More from YouTube', ...}

- Resolution
Basic sanitization for the song entry