### PR TITLE
Update README.md to reflect the correct spotify developer page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Simply copy `settings.ini.example` to a new file `settings.ini`:
 $ cp settings.ini.example settings.ini
 ```
 
-2. Generate a new app at https://developer.spotify.com/my-applications
+2. Generate a new app at https://developer.spotify.com/dashboard
 
 3. Fill in your `client_id` and `client_secret` from your Spotify app
 


### PR DESCRIPTION
The Spotify Developer Page currently listed on the README.md brings up a 404 Error.

I have swapped the URL to go to the current URL for the Spotify Developer Dashboard